### PR TITLE
Change: Cert file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## [3.2.0](https://github.com/conekta/conekta-node/releases/tag/3.1.6) - 2017-09-11
+### Change
+- Change Cert file bundle with public one
+
 ## [3.1.6](https://github.com/conekta/conekta-node/releases/tag/3.1.6) - 2017-08-01
 ### Fix
--This version solves the error that only brings the last order of a list
+- This version solves the error that only brings the last order of a list
 
 ## [3.1.5](https://github.com/conekta/conekta-node/releases/tag/3.1.5) - 2017-06-29
 ### Fix

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![README Cover Image](readme_cover.png)
 
-Conekta Node v 3.1.6
+Conekta Node v 3.2.0
 ======================
 
 Wrapper to connect with https://api.conekta.io.
@@ -15,7 +15,7 @@ This last release works with API 2, if you are using 1.0 type:
 
 
 ```sh
-npm install conekta@2.2.0
+npm install conekta@3.2.0
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conekta",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "Conekta node Wrapper",
   "keywords": [
     "conekta",


### PR DESCRIPTION
Change: Cert file
Change cert file to provide connection between clients and conekta api servers this change is needed in order to upload to npm.
This version bump increase the second digit because is a change of a functionality, it was taken from SEMVER [conektawiki](https://conekta.atlassian.net/wiki/spaces/EN/pages/4587526/Release+Management.) framework