### PR TITLE
Bugfix when req is undefined and err exists

### DIFF
--- a/lib/base64.js
+++ b/lib/base64.js
@@ -1,4 +1,4 @@
-var util = require('util');
+const util = require('util')
 
 /*
  * Encodes binary data as standard base64 with padding.
@@ -10,13 +10,13 @@ var util = require('util');
  * @return {String} the base64 encoded version of `input`.
  */
 exports.encode = function (input) {
-    var binInput;
-    if (Buffer.isBuffer(input)) {
-        binInput = input;
-    } else if (typeof input === typeof('')) {
-        binInput = new Buffer(input, 'utf8');
-    } else {
-        throw new Error("Expected string of buffer, instead got `" + typeof(input) + "`");
-    }
-    return binInput.toString('base64');
-};
+  let binInput
+  if (Buffer.isBuffer(input)) {
+    binInput = input
+  } else if (typeof input === typeof ('')) {
+    binInput = new Buffer(input, 'utf8')
+  } else {
+    throw new Error('Expected string of buffer, instead got `' + typeof (input) + '`')
+  }
+  return binInput.toString('base64')
+}

--- a/lib/conekta.js
+++ b/lib/conekta.js
@@ -1,131 +1,132 @@
-'use strict';
+'use strict'
 
 /*
  * Global packages required
  */
-var _ = require('underscore'),
-  os = require('os');
+const _ = require('underscore')
+const request = require('request')
+const path = require('path')
+const fs = require('fs')
+const os = require('os')
 
 /*
  * Project packages required
  */
-var base64 = require('./base64.js'),
-  pkg = require('../package'),
-  locales = require('./locales.json');
+const base64 = require('./base64.js')
+const pkg = require('../package')
+const locales = require('./locales.json')
 
 /*
  * Global project constants
  */
-var API_VERSION = '2.0.0',
-  API_BASE = 'https://api.conekta.io',
-  ERROR_PAGINATION = {
-    details: [
-      {
-        message: 'There\'s no next page url',
-        param: 'next_page_url'
-      }
-    ]
-  };
+const API_VERSION = '2.0.0'
+const API_BASE = 'https://api.conekta.io'
+const ERROR_PAGINATION = {
+  details: [
+    {
+      message: 'There\'s no next page url',
+      param: 'next_page_url'
+    }
+  ]
+}
 
-function setHeaders(version) {
-  if (!version) version = "2.0.0";
+function setHeaders (version) {
+  if (!version) version = '2.0.0'
   return {
     'Accept': ['application/vnd.conekta-v', version, '+json'].join(''),
     'Content-Type': 'application/json'
-  };
-} 
+  }
+}
 
 /*
  *  Conekta base object initialized
  */
-var Conekta = {
+const Conekta = {
   api_key: '',
   api_base: API_BASE,
   api_version: API_VERSION,
   locale: 'en'
-};
+}
 
-var Requestor = function(params) {
-  this.apiUrl = API_BASE;
+const Requestor = function (params) {
+  this.apiUrl = API_BASE
   this.headers = {
     bindings_version: ['Conekta::', pkg.version].join(''),
     lang: 'node',
     lang_version: process.version,
     publisher: 'conekta',
     uname: [os.arch(), os.platform(), os.release()].join(' ')
-  };
+  }
   /*
    * Call to API resources
    */
-  this.request = function(opts) {
+  this.request = function (opts) {
+    const certPath = path.join(__dirname.replace('/lib', ''), '/cert/ca_bundle.crt')
 
-    if (!Conekta.api_key || Conekta.api_key == '') {
+    if (!Conekta.api_key || Conekta.api_key === '') {
       opts.next({
-        message: locales[Conekta.locale ||  'en'].api_key_required,
+        message: locales[Conekta.locale || 'en'].api_key_required,
         code: 'api_key_required'
-      }, null);
-      return;
+      }, null)
+      return
     }
 
-    if ( parseInt(Conekta.api_version.split('.')[0]) < 1) {
-      console.log(locales[Conekta.locale ||  'en'].api_version_suggestion)
+    if (parseInt(Conekta.api_version.split('.')[0]) < 1) {
+      console.log(locales[Conekta.locale || 'en'].api_version_suggestion)
     }
 
     if (parseFloat(Conekta.api_version) < 2.0) {
-      console.log(locales[Conekta.locale || 'en'].api_version_unsupported);
+      console.log(locales[Conekta.locale || 'en'].api_version_unsupported)
       return opts.next({
         message: locales[Conekta.locale || 'en'].api_version_unsupported,
         code: 'api_version_unsupported'
-      });
+      })
     }
 
-    var HEADERS = setHeaders(Conekta.api_version);
+    const HEADERS = setHeaders(Conekta.api_version)
 
+    HEADERS['X-Conekta-Client-User-Agent'] = JSON.stringify(this.headers)
+    HEADERS['User-Agent'] = 'Conekta/v1 NodeBindings/' + ['Conekta::', pkg.version].join('')
+    HEADERS['Accept-Language'] = Conekta.locale
+    HEADERS['Authorization'] = ['Basic ', base64.encode(Conekta.api_key), ':'].join('')
 
-    HEADERS['X-Conekta-Client-User-Agent'] = JSON.stringify(this.headers);
-    HEADERS['User-Agent'] = 'Conekta/v1 NodeBindings/' + ['Conekta::', pkg.version].join('');
-    HEADERS['Accept-Language'] = Conekta.locale;
-    HEADERS['Authorization'] = ['Basic ', base64.encode(Conekta.api_key), ':'].join('');
-
-    var request = require('request'),
-      fs = require('fs');
-
-    var options = {
+    const options = {
       url: opts.url,
       headers: HEADERS,
       agentOptions: {
-        ca: fs.readFileSync(__dirname + '/../cert/ca_bundle.crt'),
+        ca: fs.readFileSync(certPath),
         rejectUnauthorized: false
       }
-    };
-
-    //Preventing the failure when reading the results on post or get calls
-    if (opts.method == 'get') {
-      options['qs'] = opts.data;
-    } else {
-      options['json'] = true;
-      options['body'] = opts.data;
     }
 
-    request[opts.method](options, function(err, req, res) {
-      var error = null,
-        result = null;
+    // Preventing the failure when reading the results on post or get calls
+    if (opts.method === 'get') {
+      options['qs'] = opts.data
+    } else {
+      options['json'] = true
+      options['body'] = opts.data
+    }
+
+    request[opts.method](options, function (err, req, res) {
+      let result = null
+
+      req = req || { statusCode: 520 }
 
       // Check response status code for assign error or result with data
-      if ((req.statusCode != 200 &&  req.statusCode != 201) || err) {
-        error = _.extend({
+      if ((req.statusCode !== 200 && req.statusCode !== 201) || err) {
+        err = _.extend({
           http_code: req.statusCode
-        }, res, err);
+        }, res, err)
       } else {
-        result = typeof(res) == 'object' ? res : JSON.parse(res);
+        result = typeof (res) === 'object' ? res : JSON.parse(res)
       }
 
-      opts.next(error, result);
-    });
+      opts.next(err, result)
+    })
   }
-};
+}
 
-var Resource = function(instance) {
+const Resource = function (instance) {
   return _.extend({
     _id: null,
     classUrl: '',
@@ -135,218 +136,209 @@ var Resource = function(instance) {
     /*
      * Convert objects with object = list to javascript array
      */
-    listObjectsToArray: function(response) {
-      _.each(response, function(value, key) {
-        response[key] = value;
-      });
+    listObjectsToArray: function (response) {
+      _.each(response, function (value, key) {
+        response[key] = value
+      })
 
-      return response;
+      return response
     },
     /*
      * Convert the object with functions to just
      * a representation of the resource object.
      */
-    toObject: function() {
-      return this._json;
+    toObject: function () {
+      return this._json
     },
     /*
      * Convert the object that contains a list to just
      * an array with resource objects.
      */
-    toArray: function() {
-      var items = [];
-      _.each(this._items, function(item) {
-        items.push(item.toObject());
-      });
-      return items;
+    toArray: function () {
+      var items = []
+      _.each(this._items, function (item) {
+        items.push(item.toObject())
+      })
+      return items
     },
     /*
      * Method to populate attributes that are
      * of another kind of resource.
      */
-    build_children: function() {
-
+    build_children: function () {
       // Iterate children_resources
-      _.each(this.children_resources, function(resource, resource_name) {
-
+      _.each(this.children_resources, function (resource, resourceName) {
         // Iterate object json data
-        _.each(this._json, function(object, key) {
-
+        _.each(this._json, function (object, key) {
           // If children_resource and object different, next
-          if (resource_name != key) {
-            return;
+          if (resourceName !== key) {
+            return
           }
 
           if (object instanceof Array) {
-
             /*
              * Iterate array object to extend from
              * target Conekta resource and overwrite attribute
              */
-            var children_objects = [];
-            _.each(object, function(elem) {
-              var resource_instance = _.extend({},
+            var childrenObjects = []
+            _.each(object, function (elem) {
+              var resourceInstance = _.extend({},
                 Conekta[resource]
-              );
-              children_objects.push(
-                _.extend(resource_instance, {
+              )
+              childrenObjects.push(
+                _.extend(resourceInstance, {
                   _json: elem,
                   _id: elem.id
                 })
-              );
-            });
+              )
+            })
 
             /* overwrite property */
-            this[key] = children_objects;
-
+            this[key] = childrenObjects
           } else {
-
             if (object) {
               /* overwrite property */
               this[key] = _.extend(Conekta[resource], {
                 _json: object,
                 _id: object.id
-              });
+              })
             }
-
           }
-
-        }.bind(this));
-
-      }.bind(this));
+        }.bind(this))
+      }.bind(this))
     },
     /*
      * Method to build GET calls
      */
-    get: function(opts, id) {
-      var uri = this.classUrl;
+    get: function (opts, id) {
+      var uri = this.classUrl
       if (id) {
-        uri += '/' + id;
+        uri += '/' + id
       }
 
-      if (typeof opts.data == 'function') {
-        opts.next = opts.data;
-        opts.data = {};
+      if (typeof opts.data === 'function') {
+        opts.next = opts.data
+        opts.data = {}
       }
 
       new Requestor({api_version: instance.api_version}).request({
         method: 'get',
         url: [Conekta.api_base, uri].join(''),
-        data: opts.data ||  {},
-        next: function(error, result) {
+        data: opts.data || {},
+        next: function (error, result) {
           if (error) {
-            return opts.next(error, null);
+            return opts.next(error, null)
           }
 
-          result = this.listObjectsToArray(result);
-          this._json = result;
+          result = this.listObjectsToArray(result)
+          this._json = result
           if (id) {
-            this._id = result.id;
+            this._id = result.id
           } else {
-            _.each(result.data, function(item) {
+            _.each(result.data, function (item) {
               var index = _.extend({
                 _json: item,
                 _id: item._id
-              }, this);
-              this._items.push(index);
-            }.bind(this));
+              }, this)
+              this._items.push(index)
+            }.bind(this))
           }
-          this.build_children();
-          opts.next(null, this);
+          this.build_children()
+          opts.next(null, this)
         }.bind(this)
-      });
+      })
     },
     /*
      * Method to build POST calls
      */
-    post: function(opts, id) {
-      var uri = this.classUrl;
+    post: function (opts, id) {
+      var uri = this.classUrl
       if (id) {
-        uri += '/' + id;
+        uri += '/' + id
       }
 
       new Requestor({api_version: instance.api_version}).request({
         method: 'post',
         url: [Conekta.api_base, uri].join(''),
-        data: opts.data ||  {},
-        next: function(error, response) {
+        data: opts.data || {},
+        next: function (error, response) {
           if (error) {
-            return opts.next(error, null);
+            return opts.next(error, null)
           }
-          response = this.listObjectsToArray(response);
-          this._json = response;
-          this._id = response.id;
-          this.build_children();
-          opts.next(null, this);
+          response = this.listObjectsToArray(response)
+          this._json = response
+          this._id = response.id
+          this.build_children()
+          opts.next(null, this)
         }.bind(this)
-      });
+      })
     },
     /*
      * Method to build PUT calls
      */
-    put: function(opts, id) {
-      var uri = this.classUrl;
+    put: function (opts, id) {
+      var uri = this.classUrl
       if (id) {
-        uri += '/' + id;
+        uri += '/' + id
       }
       new Requestor({api_version: instance.api_version}).request({
         method: 'put',
         url: [Conekta.api_base, uri].join(''),
-        data: opts.data ||  {},
-        next: function(error, response) {
+        data: opts.data || {},
+        next: function (error, response) {
           if (error) {
-            return opts.next(error, null);
+            return opts.next(error, null)
           }
-          response = this.listObjectsToArray(response);
-          this._json = response;
-          this._id = response.id;
-          this.build_children();
-          opts.next(null, this);
+          response = this.listObjectsToArray(response)
+          this._json = response
+          this._id = response.id
+          this.build_children()
+          opts.next(null, this)
         }.bind(this)
-      });
+      })
     },
     /*
      * Method to build DEL calls
      */
-    del: function(opts, id) {
-      var uri = this.classUrl;
+    del: function (opts, id) {
+      var uri = this.classUrl
       if (id) {
-        uri += '/' + id;
+        uri += '/' + id
       }
 
       new Requestor({api_version: instance.api_version}).request({
         method: 'del',
         url: [Conekta.api_base, uri].join(''),
-        data: opts.data ||  {},
-        next: function(error, response) {
+        data: opts.data || {},
+        next: function (error, response) {
           if (error) {
-            return opts.next(error, null);
+            return opts.next(error, null)
           }
-          response = this.listObjectsToArray(response);
-          this._json = response;
-          this.build_children();
-          opts.next(null, this);
+          response = this.listObjectsToArray(response)
+          this._json = response
+          this.build_children()
+          opts.next(null, this)
         }.bind(this)
-      });
+      })
     },
     /*
      * Method to build complex api calls
      */
-    custom: function(method, customURI, opts) {
+    custom: function (method, customURI, opts) {
       new Requestor({api_version: instance.api_version}).request({
         method: method,
         url: [Conekta.api_base, customURI].join(''),
-        data: opts.data ||  {},
-        next: function(err, response) {
-          response = this.listObjectsToArray(response);
-          opts.next(err, response);
+        data: opts.data || {},
+        next: function (err, response) {
+          response = this.listObjectsToArray(response)
+          opts.next(err, response)
         }.bind(this)
-      });
+      })
     }
-  }, instance);
+  }, instance)
 }
 
-var Order = new Resource({
+const Order = new Resource({
   classUrl: '/orders',
   children_resources: {
     'line_items': 'LineItem',
@@ -355,24 +347,24 @@ var Order = new Resource({
     'discount_lines': 'DiscountLine',
     'charges': 'Charge'
   },
-  find: function(id, next) {
+  find: function (id, next) {
     this.get({
       next: next
-    }, id);
+    }, id)
   },
-  where: function(data, next) {
+  where: function (data, next) {
     this.get({
       data: data,
       next: next
-    });
+    })
   },
-  create: function(data, next) {
+  create: function (data, next) {
     this.post({
       data: data,
       next: next
-    });
+    })
   },
-  update: function(data, next) {
+  update: function (data, next) {
     this.put({
       data: data,
       next: next
@@ -383,11 +375,11 @@ var Order = new Resource({
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createShippingContact: function (data, next) {
     data = {
@@ -397,237 +389,237 @@ var Order = new Resource({
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res._json.shipping_contact);
+        next(null, res._json.shipping_contact)
       }
-    }, this._id);
+    }, this._id)
   },
   createLineItem: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'line_items'].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createTaxLine: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'tax_lines'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createShippingLine: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'shipping_lines'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createDiscountLine: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'discount_lines'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createCharge: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'charges'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createRefund: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'refunds'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   }
-});
+})
 
-var Charge = new Resource({
+const Charge = new Resource({
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-var LineItem = new Resource({
+const LineItem = new Resource({
   classUrl: '/orders',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'line_items', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   delete: function (next) {
     this.custom('del', [this.classUrl, this._json.parent_id, 'line_items', this._id].join('/'), {
       data: {},
       next: function (err, res) {
-        if(err) {
-          return next(err, null);
+        if (err) {
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
 })
 
-var TaxLine = new Resource({
+const TaxLine = new Resource({
   classUrl: '/orders',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'tax_lines', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   },
   delete: function (next) {
     this.custom('del', [this.classUrl, this._json.parent_id, 'tax_lines', this._id].join('/'), {
       data: {},
-      next: function (err, res) {
+      next: (err, res) => {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   }
-});
+})
 
-var ShippingLine = new Resource({
+const ShippingLine = new Resource({
   classUrl: '/orders',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'shipping_lines', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   },
   delete: function (next) {
@@ -635,46 +627,46 @@ var ShippingLine = new Resource({
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-var DiscountLine = new Resource({
+const DiscountLine = new Resource({
   classUrl: '/orders',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'discount_lines', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   },
   delete: function (next) {
@@ -682,295 +674,293 @@ var DiscountLine = new Resource({
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-
-var Plan = new Resource({
+const Plan = new Resource({
   classUrl: '/plans',
   children_resources: {},
-  where: function(data, next) {
+  where: function (data, next) {
     this.get({
       data: data,
       next: next
-    });
+    })
   },
-  find: function(id, next) {
+  find: function (id, next) {
     this.get({
       data: {},
       next: next
-    }, id);
+    }, id)
   },
-  create: function(data, next) {
+  create: function (data, next) {
     this.post({
       data: data,
       next: next
-    });
+    })
   },
-  update: function(data, next) {
+  update: function (data, next) {
     this.put({
       data: data,
       next: next
-    }, this._id);
+    }, this._id)
   },
-  delete: function(next) {
+  delete: function (next) {
     this.del({
       data: {},
       next: next
-    }, this._id);
+    }, this._id)
   }
-});
+})
 
-var Event = new Resource({
+const Event = new Resource({
   classUrl: '/events',
   children_resources: {},
-  where: function(data, next) {
+  where: function (data, next) {
     this.get({
       data: data,
       next: next
-    });
+    })
   }
-});
+})
 
-var Customer = new Resource({
+const Customer = new Resource({
   classUrl: '/customers',
   children_resources: {
     'payment_sources': 'Card',
     'subscription': 'Subscription',
     'shipping_contacts': 'ShippingContact'
   },
-  where: function(data, next) {
+  where: function (data, next) {
     this.get({
       data: data,
       next: next
-    });
+    })
   },
-  find: function(id, next) {
+  find: function (id, next) {
     this.get({
       next: next
-    }, id);
+    }, id)
   },
-  create: function(data, next) {
+  create: function (data, next) {
     this.post({
       data: data,
       next: next
-    });
+    })
   },
-  update: function(data, next) {
+  update: function (data, next) {
     this.put({
       data: data,
       next: next
-    }, this._id);
+    }, this._id)
   },
-  delete: function(next) {
+  delete: function (next) {
     this.del({
       data: {},
       next: next
-    }, this._id);
+    }, this._id)
   },
-  createCard: function(data, next) {
+  createCard: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'payment_sources'].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  createSubscription: function(data, next) {
+  createSubscription: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'subscription'].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   createShippingContact: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'shipping_contacts'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    }); 
+        next(null, res)
+      }
+    })
   },
   createPaymentSource: function (data, next) {
     this.custom('post', [this.classUrl, this._id, 'payment_sources'].join('/'), {
       data: data,
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   }
-});
+})
 
-var ShippingContact = new Resource({
+const ShippingContact = new Resource({
   classUrl: '/customers',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
   update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'shipping_contacts', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
+        next(null, res)
+      }
     })
   },
-  delete: function(next) {
+  delete: function (next) {
     this.custom('del', [this.classUrl, this._json.parent_id, 'shipping_contacts', this._id].join('/'), {
       data: {},
-      next:function (err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-var Card = new Resource({
+const Card = new Resource({
   classUrl: '/customers',
   get: function (position) {
-    this.build_children();
+    this.build_children()
     this._id = this._json.data[position].id
-    this._json = this._json.data[position];
-    return this;
+    this._json = this._json.data[position]
+    return this
   },
   nextPage: function (next) {
     if (!this._json.next_page_url) {
-      return next(ERROR_PAGINATION, null);
+      return next(ERROR_PAGINATION, null)
     }
 
     this.custom('get', this._json.next_page_url.replace(API_BASE, ''), {
       data: {},
       next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  update: function(data, next) {
+  update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.parent_id, 'payment_sources', this._id].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  delete: function(next) {
-
+  delete: function (next) {
     this.custom('del', [this.classUrl, this._json.parent_id, 'payment_sources', this._id].join('/'), {
       data: {},
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
 
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-var Subscription = new Resource({
+const Subscription = new Resource({
   classUrl: '/customers',
-  update: function(data, next) {
+  update: function (data, next) {
     this.custom('put', [this.classUrl, this._json.customer_id, 'subscription'].join('/'), {
       data: data,
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  pause: function(next) {
+  pause: function (next) {
     this.custom('post', [this.classUrl, this._json.customer_id, 'subscription', 'pause'].join('/'), {
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  resume: function(next) {
+  resume: function (next) {
     this.custom('post', [this.classUrl, this._json.customer_id, 'subscription', 'resume'].join('/'), {
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   },
-  cancel: function(next) {
+  cancel: function (next) {
     this.custom('post', [this.classUrl, this._json.customer_id, 'subscription', 'cancel'].join('/'), {
-      next: function(err, res) {
+      next: function (err, res) {
         if (err) {
-          return next(err, null);
+          return next(err, null)
         }
-        next(null, res);
-      }.bind(this)
-    });
+        next(null, res)
+      }
+    })
   }
-});
+})
 
-Conekta.Order = Order;
-Conekta.LineItem = LineItem;
-Conekta.TaxLine = TaxLine;
-Conekta.ShippingLine = ShippingLine;
-Conekta.DiscountLine = DiscountLine;
-Conekta.Event = Event;
-Conekta.Customer = Customer;
-Conekta.ShippingContact = ShippingContact;
-Conekta.Card = Card;
-Conekta.Subscription = Subscription;
-Conekta.Charge = Charge;
-Conekta.Plan = Plan;
+Conekta.Order = Order
+Conekta.LineItem = LineItem
+Conekta.TaxLine = TaxLine
+Conekta.ShippingLine = ShippingLine
+Conekta.DiscountLine = DiscountLine
+Conekta.Event = Event
+Conekta.Customer = Customer
+Conekta.ShippingContact = ShippingContact
+Conekta.Card = Card
+Conekta.Subscription = Subscription
+Conekta.Charge = Charge
+Conekta.Plan = Plan
 
-module.exports = Conekta;
+module.exports = Conekta

--- a/package.json
+++ b/package.json
@@ -23,14 +23,19 @@
     "type": "git",
     "url": "https://github.com/conekta/conekta-node.git"
   },
+  "engines": {
+    "node": ">=0.10.48",
+    "npm": ">=2.15.1"
+  },
   "dependencies": {
     "request": "2.55.0",
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "mocha": "2.2.5",
     "coffee-script": "^1.10.0",
-    "nesh": "^1.6.0"
+    "mocha": "2.2.5",
+    "nesh": "^1.6.0",
+    "nock": "^9.1.0"
   },
   "main": "./lib/conekta.js",
   "engines": {


### PR DESCRIPTION
**Why is this change neccesary?**
Sometimes `req` attribute arrive like `undefined`, in this cases `err` attribute includes the fail reasons. Now this stage is correctly handled. No error translated is returned because several things external to API can cause this behaivor. A 520(unknown error) http code is returned in this case in order to follow general practices: http://getstatuscode.com/520

Some style improvements applied.

**How does it address the issue?**
Now handled correctly when `err` attribute != null

**What side effects does this change have?**
No crash when `req` is undefined