### PR TITLE
__dirname replace issue fix

### DIFF
--- a/lib/conekta.js
+++ b/lib/conekta.js
@@ -61,7 +61,7 @@ const Requestor = function (params) {
    * Call to API resources
    */
   this.request = function (opts) {
-    const certPath = path.join(__dirname.replace('/lib', ''), '/cert/ca_bundle.crt')
+    const certPath = path.join(__dirname.replace('lib', ''), 'cert/ca_bundle.crt')
 
     if (!Conekta.api_key || Conekta.api_key === '') {
       opts.next({


### PR DESCRIPTION
replace issues with lib/cert referenced in issue #50, tested on windows 10 and location was fixed correctly