### PR TITLE
Bump request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "npm": ">=2.15.1"
   },
   "dependencies": {
-    "request": "2.55.0",
+    "request": "2.86.0",
     "underscore": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
In 2016, the `request` package migrated away from the deprecated [node-uuid](https://www.npmjs.com/package/node-uuid) package. You guys are still using an old version of `request` that uses this deprecated package, which prompts some annoying warnings while running jest tests [for some reason](https://github.com/request/request/issues/2406).

I'm just bumping request to the latest version, a minor upgrade that should not brake anything.