### PR TITLE
Allow searching of embedded objects with embedded object notation

### DIFF
--- a/lib/Requestor.js
+++ b/lib/Requestor.js
@@ -1,6 +1,7 @@
 const os = require('os')
 const fs = require('fs')
 const path = require('path')
+const qs = require('qs')
 const request = require('request')
 const _ = require('underscore')
 
@@ -79,7 +80,7 @@ function Requestor (params) {
 
     // Preventing the failure when reading the results on post or get calls
     if (opts.method === 'get') {
-      options.qs = opts.data
+      options.qs = qs.parse(qs.stringify(opts.data, { allowDots: true }))
     } else {
       options.json = true
       options.body = opts.data
@@ -100,7 +101,6 @@ function Requestor (params) {
       } else {
         result = typeof res === 'object' ? res : JSON.parse(res)
       }
-
       opts.next(err, result)
     })
   }

--- a/test/test.js
+++ b/test/test.js
@@ -14,9 +14,9 @@ const TIMEOUT = 30000
 const orderBody = {
   currency: 'MXN',
   customer_info: {
-    name: 'Jul Ceballos',
+    name: 'Fulanito Perez',
     phone: '+5215555555555',
-    email: 'jul@conekta.io'
+    email: 'fulanito@example.com'
   },
   line_items: [{
     name: 'Box of Cohiba S1s',
@@ -173,6 +173,28 @@ describe('Order', function () {
     })
   })
 
+  describe('multiple orders', () => {
+    it('should return an array of orders when using dot notation', (done) => {
+      conekta.Order.where({
+        'customer_info.email': 'fulanito@example.com'
+      }, (err, orders) => {
+        assert(orders.toObject().data instanceof Array, true)
+        assert(orders.toObject().data.length > 0, true)
+        done()
+      })
+    })
+
+    it('should return an array of orders when searching for a customer id with embedded fields', (done) => {
+      conekta.Order.where({
+        'customer_info': { 'email': 'fulanito@example.com' }
+      }, (err, orders) => {
+        assert(orders.toObject().data instanceof Array, true)
+        assert(orders.toObject().data.length > 0, true)
+        done()
+      })
+    })
+  })
+
   describe('create', () => {
     // nock.restore()
     it('should return instance object with id', (done) => {
@@ -226,9 +248,9 @@ describe('Order', function () {
   describe('capture order', () => {
     const preAuthOrd = {
       customer_info: {
-        name: 'Jul Ceballos',
+        name: 'Fulanito Perez',
         phone: '+5215555555555',
-        email: 'jul@conekta.io'
+        email: 'fulanito@example.com'
       },
       line_items: [{
         name: 'Box of Cohiba S1s',
@@ -885,9 +907,9 @@ describe('Order', function () {
     const orderChargeBody = {
       currency: 'MXN',
       customer_info: {
-        name: 'Jul Ceballos',
+        name: 'Fulanito Perez',
         phone: '+5215555555555',
-        email: 'jul@conekta.io'
+        email: 'fulanito@example.com'
       },
       line_items: [{
         name: 'Box of Cohiba S1s',


### PR DESCRIPTION
Allowing for embedded object searching as per https://github.com/conekta/conekta-node/issues/91

This causes the query options `{ 'customer_info.email': 'fulanito@example.com' }` to continue resolving to `{ 'customer_info.email': 'fulanito@example.com' }`.  Additionally `{ customer_info: { email: 'fulanito@example.com' } }` now also resolves resolve to `{ 'customer_info.email': 'fulanito@example.com' }`