### PR TITLE
Update readme file to prevent confusions with apikey in configuration class

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ In order to submit http request to Conekta API you need to initialize the client
 ```ts
 import { CustomersApi, Configuration, Customer, CustomerResponse } from "conekta";
 
-const apikey = "key_xxxxx";
-const config = new Configuration({ accessToken: apikey });
+const accessToken = "key_xxxxx";
+const config = new Configuration({ accessToken: accessToken });
 const client = new CustomersApi(config);
 
 const customer: Customer = {


### PR DESCRIPTION
**Description**

I spent a couple of hours trying to figure out why my requests were failing, turns out I used `apikey` instead of **accessToken** in the configuration class and passed the private key from my admin dashboard. this is confusing since we can now have short hand property assignments like.

```ts
const accessToken = 'example';
const config = {
  accessToken
}
```

**Tested scenarios**
N/A

**Fixed issue**:  <!-- #-prefixed issue number -->
??
